### PR TITLE
Make camera tab optional

### DIFF
--- a/Sources/Gallery/GalleryController.swift
+++ b/Sources/Gallery/GalleryController.swift
@@ -91,13 +91,20 @@ public class GalleryController: UIViewController, PermissionControllerDelegate {
   }
 
   func makePagesController() -> PagesController {
-    var controllers: [UIViewController] = [imagesController, cameraController]
+    var controllers: [UIViewController] = [imagesController]
+    if Config.showsCameraTab {
+      controllers.append(cameraController)
+    }
     if Config.showsVideoTab {
       controllers.append(videosController)
     }
 
     let controller = PagesController(controllers: controllers)
-    controller.selectedIndex = Page.camera.rawValue
+    if Config.showsCameraTab {
+      controller.selectedIndex = Page.camera.rawValue
+    } else {
+      controller.selectedIndex = Page.images.rawValue
+    }
 
     return controller
   }

--- a/Sources/Utils/Config.swift
+++ b/Sources/Utils/Config.swift
@@ -4,6 +4,7 @@ import AVFoundation
 public struct Config {
 
   public static var showsVideoTab: Bool = true
+  public static var showsCameraTab: Bool = true
 
   public struct PageIndicator {
     public static var backgroundColor: UIColor = UIColor(red: 0, green: 3/255, blue: 10/255, alpha: 1)

--- a/Sources/Utils/Pages/PagesController.swift
+++ b/Sources/Utils/Pages/PagesController.swift
@@ -69,7 +69,10 @@ class PagesController: UIViewController {
   // MARK: - Setup
 
   func setup() {
-    view.addSubview(pageIndicator)
+    let usePageIndicator = controllers.count > 1
+    if usePageIndicator {
+      view.addSubview(pageIndicator)
+    }
     view.addSubview(scrollView)
     scrollView.addSubview(scrollViewContentView)
 
@@ -77,7 +80,11 @@ class PagesController: UIViewController {
     pageIndicator.g_pin(height: 40)
 
     scrollView.g_pinUpward()
-    scrollView.g_pin(on: .bottom, view: pageIndicator, on: .top)
+    if usePageIndicator {
+      scrollView.g_pin(on: .bottom, view: pageIndicator, on: .top)
+    } else {
+      scrollView.g_pinDownward()
+    }
 
     scrollViewContentView.g_pinEdges()
 


### PR DESCRIPTION
This makes the camera tab optional. If it's not present, the Images tab is the first one selected.