### PR TITLE
Improve tab selection code. Let users pick a default tab.

### DIFF
--- a/Sources/Gallery/GalleryController.swift
+++ b/Sources/Gallery/GalleryController.swift
@@ -91,19 +91,28 @@ public class GalleryController: UIViewController, PermissionControllerDelegate {
   }
 
   func makePagesController() -> PagesController {
-    var controllers: [UIViewController] = [imagesController]
-    if Config.showsCameraTab {
-      controllers.append(cameraController)
+    var controllers: [UIViewController] = []
+    for tab in Config.tabsToShow {
+      if tab == .imageTab {
+        controllers.append(imagesController)
+      } else if tab == .cameraTab {
+        controllers.append(cameraController)
+      } else if tab == .videoTab {
+        controllers.append(videosController)
+      }
     }
-    if Config.showsVideoTab {
-      controllers.append(videosController)
-    }
+    assert(!controllers.isEmpty, "Must specify at least one controller.")
 
     let controller = PagesController(controllers: controllers)
-    if Config.showsCameraTab {
-      controller.selectedIndex = Page.camera.rawValue
+    if let initialTab = Config.initialTab {
+      assert(Config.tabsToShow.index(of: initialTab) != nil, "Must specify an initial tab that is in Config.tabsToShow.")
+      controller.selectedIndex = Config.tabsToShow.index(of: initialTab)!
     } else {
-      controller.selectedIndex = Page.images.rawValue
+      if let cameraIndex = Config.tabsToShow.index(of: .cameraTab) {
+        controller.selectedIndex = cameraIndex
+      } else {
+        controller.selectedIndex = 0
+      }
     }
 
     return controller

--- a/Sources/Gallery/GalleryController.swift
+++ b/Sources/Gallery/GalleryController.swift
@@ -15,10 +15,6 @@ public class GalleryController: UIViewController, PermissionControllerDelegate {
   lazy var cameraController: CameraController = self.makeCameraController()
   lazy var videosController: VideosController = self.makeVideosController()
 
-  enum Page: Int {
-    case images, camera, videos
-  }
-
   lazy var pagesController: PagesController = self.makePagesController()
   lazy var permissionController: PermissionController = self.makePermissionController()
   public weak var delegate: GalleryControllerDelegate?
@@ -41,7 +37,7 @@ public class GalleryController: UIViewController, PermissionControllerDelegate {
 
     setup()
 
-    if Permission.hasPermissions {
+    if Permission.hasNeededPermissions {
       showMain()
     } else {
       showPermissionView()

--- a/Sources/Utils/Config.swift
+++ b/Sources/Utils/Config.swift
@@ -3,8 +3,31 @@ import AVFoundation
 
 public struct Config {
 
-  public static var showsVideoTab: Bool = true
-  public static var showsCameraTab: Bool = true
+  @available(*, deprecated, message: "Use tabsToShow instead.")
+  public static var showsVideoTab: Bool {
+    // Maintains backwards-compatibility.
+    get {
+      return tabsToShow.index(of: .videoTab) != nil
+    }
+    set(newValue) {
+      if !newValue {
+        tabsToShow = tabsToShow.filter({$0 != .videoTab})
+      } else {
+        if tabsToShow.index(of: .videoTab) == nil {
+          tabsToShow.append(.videoTab)
+        }
+      }
+    }
+  }
+  public static var tabsToShow: [GalleryTab] = [.imageTab, .cameraTab, .videoTab]
+  // Defaults to cameraTab if present, or whatever tab is first if cameraTab isn't present.
+  public static var initialTab: GalleryTab?
+  
+  public enum GalleryTab {
+    case imageTab
+    case cameraTab
+    case videoTab
+  }
 
   public struct PageIndicator {
     public static var backgroundColor: UIColor = UIColor(red: 0, green: 3/255, blue: 10/255, alpha: 1)

--- a/Sources/Utils/Permission/Permission.swift
+++ b/Sources/Utils/Permission/Permission.swift
@@ -4,11 +4,15 @@ import AVFoundation
 
 struct Permission {
 
-  static var hasPermissions: Bool {
-    return Photos.hasPermission && Camera.hasPermission
+  static var hasNeededPermissions: Bool {
+    return (!Photos.needsPermission || Photos.hasPermission) && (!Camera.needsPermission || Camera.hasPermission)
   }
 
   struct Photos {
+    static var needsPermission: Bool {
+      return Config.tabsToShow.index(of: .imageTab) != nil || Config.tabsToShow.index(of: .videoTab) != nil
+    }
+    
     static var hasPermission: Bool {
       return PHPhotoLibrary.authorizationStatus() == .authorized
     }
@@ -21,6 +25,10 @@ struct Permission {
   }
 
   struct Camera {
+    static var needsPermission: Bool {
+      return Config.tabsToShow.index(of: .cameraTab) != nil
+    }
+
     static var hasPermission: Bool {
       return AVCaptureDevice.authorizationStatus(forMediaType: AVMediaTypeVideo) == .authorized
     }

--- a/Sources/Utils/Permission/PermissionController.swift
+++ b/Sources/Utils/Permission/PermissionController.swift
@@ -38,17 +38,21 @@ class PermissionController: UIViewController {
   // MARK: - Logic
 
   func requestPermission() {
-    Permission.Photos.request {
-      self.check()
+    if Permission.Photos.needsPermission {
+      Permission.Photos.request {
+        self.check()
+      }
     }
 
-    Permission.Camera.request {
-      self.check()
+    if Permission.Camera.needsPermission {
+      Permission.Camera.request {
+        self.check()
+      }
     }
   }
 
   func check() {
-    if Permission.hasPermissions {
+    if Permission.hasNeededPermissions {
       DispatchQueue.main.async {
         self.delegate?.permissionControllerDidFinish(self)
       }

--- a/Sources/Utils/Permission/PermissionView.swift
+++ b/Sources/Utils/Permission/PermissionView.swift
@@ -37,7 +37,7 @@ class PermissionView: UIView {
 
     label.g_pin(on: .bottom, view: settingButton, on: .top, constant: -33)
     label.g_pinHorizontally(padding: 50)
-    label.g_pin(greaterThanHeight: 20)
+    label.g_pin(greaterThanHeight: 200)
 
     imageView.g_pinCenter()
     imageView.g_pin(on: .bottom, view: label, on: .top, constant: -12)
@@ -58,7 +58,7 @@ class PermissionView: UIView {
     }
     label.textAlignment = .center
     label.numberOfLines = 0
-    label.lineBreakMode = .byWordWrapping  // FIXME: On a narrow display, long text still won't show a second line. It will show if we increase the greaterThanHeight to 40.
+    label.lineBreakMode = .byWordWrapping
 
     return label
   }

--- a/Sources/Utils/Permission/PermissionView.swift
+++ b/Sources/Utils/Permission/PermissionView.swift
@@ -49,9 +49,16 @@ class PermissionView: UIView {
     let label = UILabel()
     label.textColor = Config.Permission.textColor
     label.font = Config.Font.Text.regular.withSize(14)
-    label.text = "Gallery.Permission.Info".g_localize(fallback: "Please enable photos and camera")
+    if !Permission.Camera.needsPermission && Permission.Photos.needsPermission {
+      label.text = "Gallery.Permission.Info".g_localize(fallback: "Please grant access to photos.")
+    } else if Permission.Camera.needsPermission && !Permission.Photos.needsPermission {
+      label.text = "Camera.Permission.Info".g_localize(fallback: "Please grant access to the camera.")
+    } else {
+      label.text = "GalleryAndCamera.Permission.Info".g_localize(fallback: "Please grant access to photos and the camera.")
+    }
     label.textAlignment = .center
     label.numberOfLines = 0
+    label.lineBreakMode = .byWordWrapping  // FIXME: On a narrow display, long text still won't show a second line. It will show if we increase the greaterThanHeight to 40.
 
     return label
   }


### PR DESCRIPTION
There's a bunch of code here to maintain backwards-compatibility. In particular, two pieces I don't love:

1. Setting and getting "showsVideoTab" now does some function calls, again to maintain backwards-compatibility. If you're comfortable simply deprecating it and having it do nothing, I can remove that; otherwise perhaps it could be removed in a later version.

2. Having the "camera" tab be the default one open is a bit of an odd choice in a library called "Gallery", particularly given that it isn't even the first tab by default. To maintain backwards-compatibility there's some logic basically saying "If the user didn't set a default tab, default to the camera tab if it's present; otherwise default to the 0th tab." I'd much prefer to default to the 0th tab without worrying about the presence of the camera tab, but again this would be a change in behaviour.

I'd like to hear your thoughts on these points as maintainers of the library, and I'll plan to update my change accordingly.