### PR TITLE
CameraView: Fix invalid constraints on iOS < 11

### DIFF
--- a/Sources/Camera/CameraView.swift
+++ b/Sources/Camera/CameraView.swift
@@ -81,8 +81,8 @@ class CameraView: UIView, UIGestureRecognizerDelegate {
       )
     } else {
       Constraint.on(
-        closeButton.topAnchor.constraint(equalTo: superview!.topAnchor),
-        rotateButton.topAnchor.constraint(equalTo: superview!.topAnchor)
+        closeButton.topAnchor.constraint(equalTo: topAnchor),
+        rotateButton.topAnchor.constraint(equalTo: topAnchor)
       )
     }
 


### PR DESCRIPTION
This patch fixes a regression that would cause a crash on iOS < 11 since the subviews of `CameraView` were anchored to its superview, which at the point of setup is `nil`.