### PR TITLE
Added new tab to be able to access images through Files

### DIFF
--- a/Gallery.xcodeproj/project.pbxproj
+++ b/Gallery.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B2128B3920A3AE900005189D /* FilesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2128B3820A3AE900005189D /* FilesController.swift */; };
 		D24CF7321E93D1FB002E6484 /* Gallery.bundle in Resources */ = {isa = PBXBuildFile; fileRef = D24CF7311E93D1FB002E6484 /* Gallery.bundle */; };
 		D27B72ED1D6EEEC80093318F /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27B72EC1D6EEEC80093318F /* Tests.swift */; };
 		D2D1A6CA1F84F4DB0083D4C5 /* Album.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D1A6901F84F4DB0083D4C5 /* Album.swift */; };
@@ -71,6 +72,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B2128B3820A3AE900005189D /* FilesController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilesController.swift; sourceTree = "<group>"; };
 		D24CF7311E93D1FB002E6484 /* Gallery.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Gallery.bundle; sourceTree = "<group>"; };
 		D27B72EC1D6EEEC80093318F /* Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
 		D27B730C1D6EF04D0093318F /* Cartography.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cartography.framework; path = Carthage/Build/iOS/Cartography.framework; sourceTree = "<group>"; };
@@ -149,6 +151,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		B2128B3A20A3AE940005189D /* Files */ = {
+			isa = PBXGroup;
+			children = (
+				B2128B3820A3AE900005189D /* FilesController.swift */,
+			);
+			path = Files;
+			sourceTree = "<group>";
+		};
 		D24CF7301E93D1FB002E6484 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -330,6 +340,7 @@
 		D5C629691C3A809D007F7B7C /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				B2128B3A20A3AE940005189D /* Files */,
 				D2D1A6BB1F84F4DB0083D4C5 /* Camera */,
 				D2D1A6C21F84F4DB0083D4C5 /* Gallery */,
 				D2D1A68F1F84F4DB0083D4C5 /* Images */,
@@ -470,6 +481,7 @@
 				D2D1A6EF1F84F4DB0083D4C5 /* CameraMan.swift in Sources */,
 				D2D1A6E21F84F4DB0083D4C5 /* PermissionController.swift in Sources */,
 				D2D1A6CD1F84F4DB0083D4C5 /* ImageCell.swift in Sources */,
+				B2128B3920A3AE900005189D /* FilesController.swift in Sources */,
 				D2D1A6D21F84F4DB0083D4C5 /* DropdownController.swift in Sources */,
 				D2D1A6D41F84F4DB0083D4C5 /* Array+Extensions.swift in Sources */,
 				D2D1A6F71F84F4DB0083D4C5 /* VideoCell.swift in Sources */,

--- a/Gallery.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Gallery.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Files/FilesController.swift
+++ b/Sources/Files/FilesController.swift
@@ -1,0 +1,36 @@
+//
+//  FilesController.swift
+//  Gallery-iOS
+//
+//  Created by Johan Sverin on 2018-01-04.
+//  Copyright © 2018 Hyper Interaktiv AS. All rights reserved.
+//
+
+import UIKit
+
+class FilesController: UIDocumentPickerViewController, UIDocumentPickerDelegate {
+    
+    let cart: Cart
+    
+    public init(cart: Cart) {
+        self.cart = cart
+        super.init(documentTypes: ["public.image"], in: .import)
+        if #available(iOS 11.0, *) {
+            self.allowsMultipleSelection = true
+        }
+        cart.delegates.add(self)
+        self.delegate = self
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        for url in urls {
+            cart.add(url)
+        }
+        EventHub.shared.doneWithFiles?()
+    }
+    
+}

--- a/Sources/Gallery/GalleryController.swift
+++ b/Sources/Gallery/GalleryController.swift
@@ -142,7 +142,7 @@ public class GalleryController: UIViewController, PermissionControllerDelegate {
       }
     }
     
-    EventHub.shared.doneWithImages = { [weak self] in
+    EventHub.shared.doneWithFiles = { [weak self] in
       if let strongSelf = self {
         strongSelf.delegate?.galleryController(strongSelf, didSelectFiles: strongSelf.cart.urls)
       }

--- a/Sources/Gallery/GalleryController.swift
+++ b/Sources/Gallery/GalleryController.swift
@@ -3,6 +3,7 @@ import AVFoundation
 
 public protocol GalleryControllerDelegate: class {
 
+  func galleryController(_ controller: GalleryController, didSelectFiles files: [URL])
   func galleryController(_ controller: GalleryController, didSelectImages images: [Image])
   func galleryController(_ controller: GalleryController, didSelectVideo video: Video)
   func galleryController(_ controller: GalleryController, requestLightbox images: [Image])
@@ -66,6 +67,13 @@ public class GalleryController: UIViewController, PermissionControllerDelegate {
 
     return controller
   }
+    
+  func makeFilesController() -> FilesController {
+    let controller = FilesController(cart: cart)
+    controller.title = "Gallery.Files.Title".g_localize(fallback: "FILES")
+        
+    return controller
+  }
 
   func makePagesController() -> PagesController? {
     guard Permission.Photos.status == .authorized else {
@@ -83,6 +91,8 @@ public class GalleryController: UIViewController, PermissionControllerDelegate {
         return makeCameraController()
       } else if tab == .videoTab {
         return makeVideosController()
+      } else if tab == .filesTab {
+        return makeFilesController()
       } else {
         return nil
       }
@@ -129,6 +139,12 @@ public class GalleryController: UIViewController, PermissionControllerDelegate {
     EventHub.shared.stackViewTouched = { [weak self] in
       if let strongSelf = self {
         strongSelf.delegate?.galleryController(strongSelf, requestLightbox: strongSelf.cart.images)
+      }
+    }
+    
+    EventHub.shared.doneWithImages = { [weak self] in
+      if let strongSelf = self {
+        strongSelf.delegate?.galleryController(strongSelf, didSelectFiles: strongSelf.cart.urls)
       }
     }
   }

--- a/Sources/Images/Cart.swift
+++ b/Sources/Images/Cart.swift
@@ -11,6 +11,7 @@ public protocol CartDelegate: class {
 public class Cart {
 
   public var images: [Image] = []
+  public var urls: [URL] = []
   public var video: Video?
   var delegates: NSHashTable<AnyObject> = NSHashTable.weakObjects()
 
@@ -54,6 +55,11 @@ public class Cart {
     for case let delegate as CartDelegate in delegates.allObjects {
       delegate.cartDidReload(self)
     }
+  }
+
+  public func add(_ url: URL) {
+    guard !urls.contains(url) else { return }
+    urls.append(url)
   }
 
   // MARK: - Reset

--- a/Sources/Utils/Config.swift
+++ b/Sources/Utils/Config.swift
@@ -27,6 +27,7 @@ public struct Config {
     case imageTab
     case cameraTab
     case videoTab
+    case filesTab
   }
 
   public struct PageIndicator {

--- a/Sources/Utils/EventHub.swift
+++ b/Sources/Utils/EventHub.swift
@@ -11,6 +11,7 @@ class EventHub {
   init() {}
 
   var close: Action?
+  var doneWithFiles: Action?
   var doneWithImages: Action?
   var doneWithVideos: Action?
   var stackViewTouched: Action?


### PR DESCRIPTION
Sometimes you have images stored remotely and not on your phone. By using a Files in iOS11 you're able to add all your images stored in iCloud, Dropbox, Google Drive and even other apps if they connect to Files.