### PR TITLE
Ambiguity in TripleButton (State) and warnings with Xcode 10 beta and Swift 4.2

### DIFF
--- a/Gallery.xcodeproj/project.pbxproj
+++ b/Gallery.xcodeproj/project.pbxproj
@@ -410,7 +410,6 @@
 					D5B2E89E1C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
 						LastSwiftMigration = 0800;
-						ProvisioningStyle = Manual;
 					};
 					D5B2E8A81C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
@@ -641,11 +640,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -656,7 +652,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.Gallery-iOS";
 				PRODUCT_NAME = Gallery;
-				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -666,11 +661,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -681,7 +673,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.Gallery-iOS";
 				PRODUCT_NAME = Gallery;
-				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 			};
 			name = Release;

--- a/Gallery.xcodeproj/project.pbxproj
+++ b/Gallery.xcodeproj/project.pbxproj
@@ -409,9 +409,8 @@
 				TargetAttributes = {
 					D5B2E89E1C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = DBEPTECPFM;
 						LastSwiftMigration = 0800;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					D5B2E8A81C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
@@ -644,9 +643,9 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = DBEPTECPFM;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -669,9 +668,9 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = DBEPTECPFM;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/Gallery.xcodeproj/project.pbxproj
+++ b/Gallery.xcodeproj/project.pbxproj
@@ -409,7 +409,9 @@
 				TargetAttributes = {
 					D5B2E89E1C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
+						DevelopmentTeam = DBEPTECPFM;
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
 					};
 					D5B2E8A81C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
@@ -640,8 +642,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = DBEPTECPFM;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -652,6 +657,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.Gallery-iOS";
 				PRODUCT_NAME = Gallery;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -661,8 +667,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = DBEPTECPFM;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -673,6 +682,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.Gallery-iOS";
 				PRODUCT_NAME = Gallery;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 			};
 			name = Release;

--- a/Sources/Camera/CameraView.swift
+++ b/Sources/Camera/CameraView.swift
@@ -52,7 +52,7 @@ class CameraView: UIView, UIGestureRecognizerDelegate {
     }
 
     [stackView, doneButton].forEach {
-      bottomView.addSubview($0 as! UIView)
+      bottomView.addSubview($0)
     }
 
     [closeButton, flashButton, rotateButton].forEach {
@@ -172,10 +172,10 @@ class CameraView: UIView, UIGestureRecognizerDelegate {
   }
 
   func makeFlashButton() -> TripleButton {
-    let states: [TripleButton.State] = [
-      TripleButton.State(title: "Gallery.Camera.Flash.Off".g_localize(fallback: "OFF"), image: GalleryBundle.image("gallery_camera_flash_off")!),
-      TripleButton.State(title: "Gallery.Camera.Flash.On".g_localize(fallback: "ON"), image: GalleryBundle.image("gallery_camera_flash_on")!),
-      TripleButton.State(title: "Gallery.Camera.Flash.Auto".g_localize(fallback: "AUTO"), image: GalleryBundle.image("gallery_camera_flash_auto")!)
+    let states: [TripleButton.ButtonState] = [
+      TripleButton.ButtonState(title: "Gallery.Camera.Flash.Off".g_localize(fallback: "OFF"), image: GalleryBundle.image("gallery_camera_flash_off")!),
+      TripleButton.ButtonState(title: "Gallery.Camera.Flash.On".g_localize(fallback: "ON"), image: GalleryBundle.image("gallery_camera_flash_on")!),
+      TripleButton.ButtonState(title: "Gallery.Camera.Flash.Auto".g_localize(fallback: "AUTO"), image: GalleryBundle.image("gallery_camera_flash_auto")!)
     ]
 
     let button = TripleButton(states: states)

--- a/Sources/Camera/TripleButton.swift
+++ b/Sources/Camera/TripleButton.swift
@@ -2,17 +2,17 @@ import UIKit
 
 class TripleButton: UIButton {
 
-  struct State {
+  struct ButtonState {
     let title: String
     let image: UIImage
   }
 
-  let states: [State]
+  let states: [ButtonState]
   var selectedIndex: Int = 0
 
   // MARK: - Initialization
 
-  init(states: [State]) {
+  init(states: [ButtonState]) {
     self.states = states
     super.init(frame: .zero)
     setup()

--- a/Sources/Gallery/GalleryController.swift
+++ b/Sources/Gallery/GalleryController.swift
@@ -74,9 +74,9 @@ public class GalleryController: UIViewController, PermissionControllerDelegate {
 
     let useCamera = Permission.Camera.needsPermission && Permission.Camera.status == .authorized
 
-    let tabsToShow = Config.tabsToShow.flatMap { $0 != .cameraTab ? $0 : (useCamera ? $0 : nil) }
+    let tabsToShow = Config.tabsToShow.compactMap { $0 != .cameraTab ? $0 : (useCamera ? $0 : nil) }
 
-    let controllers: [UIViewController] = tabsToShow.flatMap { tab in
+    let controllers: [UIViewController] = tabsToShow.compactMap { tab in
       if tab == .imageTab {
         return makeImagesController()
       } else if tab == .cameraTab {

--- a/Sources/Utils/Pages/PagesController.swift
+++ b/Sources/Utils/Pages/PagesController.swift
@@ -76,7 +76,7 @@ class PagesController: UIViewController {
   }
 
   func makePageIndicator() -> PageIndicator {
-    let items = controllers.flatMap { $0.title }
+    let items = controllers.compactMap { $0.title }
     let indicator = PageIndicator(items: items)
     indicator.delegate = self
 

--- a/Sources/Utils/View/AlbumCell.swift
+++ b/Sources/Utils/View/AlbumCell.swift
@@ -34,7 +34,7 @@ class AlbumCell: UITableViewCell {
 
   func setup() {
     [albumImageView, albumTitleLabel, itemCountLabel].forEach {
-      addSubview($0 as! UIView)
+        addSubview($0)
     }
 
     albumImageView.g_pin(on: .left, constant: 12)

--- a/Sources/Utils/View/EmptyView.swift
+++ b/Sources/Utils/View/EmptyView.swift
@@ -21,7 +21,7 @@ class EmptyView: UIView {
 
   private func setup() {
     [label, imageView].forEach {
-      addSubview($0 as! UIView)
+        addSubview($0)
     }
 
     label.g_pinCenter()

--- a/Sources/Utils/View/GridView.swift
+++ b/Sources/Utils/View/GridView.swift
@@ -40,7 +40,7 @@ class GridView: UIView {
     }
 
     [bottomBlurView, doneButton].forEach {
-      bottomView.addSubview($0 as! UIView)
+        bottomView.addSubview($0)
     }
 
     Constraint.on(


### PR DESCRIPTION
Hi,

Since I installed the beta version of XCode 10.0 Beta,  a few errors and warnings appeared.
I fixed all the wrapping warnings, and in order to remove the "ambiguous object error" I renamed the State object to "ButtonState" within TripleButton.

Thank you. If I did something wrong let me know, this is my first ever pull request on iOS.