### PR TITLE
Take screen scale in account when fetching thumbnail

### DIFF
--- a/Sources/Utils/Extensions/UIImageView+Extensions.swift
+++ b/Sources/Utils/Extensions/UIImageView+Extensions.swift
@@ -18,9 +18,12 @@ extension UIImageView {
     let options = PHImageRequestOptions()
     options.isNetworkAccessAllowed = true
 
+    let scale = UIScreen.main.scale
+    let size = CGSize(width: frame.width * scale, height: frame.height * scale)
+    
     let id = PHImageManager.default().requestImage(
       for: asset,
-      targetSize: frame.size,
+      targetSize: size,
       contentMode: .aspectFill,
       options: options) { [weak self] image, _ in
       self?.image = image


### PR DESCRIPTION
The requested thumbnail in the gallery requests the width and height equal to the points of the UIImageView. This does not take in account the 2x or 3x screen scale of modern devices. This can cause thumbs to be blurry. This is esspecially visible on 3x devices.

Before:
![original](https://user-images.githubusercontent.com/1032307/48540163-a33bd000-e8b9-11e8-8210-4a948ef22c89.png)

After:
![fixed](https://user-images.githubusercontent.com/1032307/48540162-a33bd000-e8b9-11e8-861d-452d255e6597.png)
