### PR TITLE
Add blacklistedAssetMediaSubtypes config variable

### DIFF
--- a/Sources/Images/Album.swift
+++ b/Sources/Images/Album.swift
@@ -17,7 +17,7 @@ class Album {
 
     let itemsFetchResult = PHAsset.fetchAssets(in: collection, options: Utils.fetchOptions())
     itemsFetchResult.enumerateObjects({ (asset, count, stop) in
-      if asset.mediaType == .image {
+      if asset.mediaType == .image && !Config.blacklistedAssetMediaSubtypes.contains(asset.mediaSubtypes) {
         self.items.append(Image(asset: asset))
       }
     })

--- a/Sources/Utils/Config.swift
+++ b/Sources/Utils/Config.swift
@@ -1,5 +1,6 @@
 import UIKit
 import AVFoundation
+import Photos
 
 public struct Config {
 
@@ -115,4 +116,6 @@ public struct Config {
     public static var portraitSize: CGSize = CGSize(width: 360, height: 640)
     public static var landscapeSize: CGSize = CGSize(width: 640, height: 360)
   }
+    
+  public static var blacklistedAssetMediaSubtypes: [PHAssetMediaSubtype] = []
 }


### PR DESCRIPTION
blacklistedAssetMediaSubtypes can be used to cause some mediaSubtypes
(Live Photos, for example) to not show up in the image tab.