### PR TITLE
fixed image size issue where images came without original size

### DIFF
--- a/Sources/Images/Image.swift
+++ b/Sources/Images/Image.swift
@@ -21,24 +21,21 @@ extension Image {
   ///
   /// - Parameter size: The target size
   /// - Returns: The resolved UIImage, otherwise nil
-  public func resolve(completion: @escaping (UIImage?) -> Void) {
-    let options = PHImageRequestOptions()
-    options.isNetworkAccessAllowed = true
-    options.deliveryMode = .highQualityFormat
-
-    let targetSize = CGSize(
-      width: asset.pixelWidth,
-      height: asset.pixelHeight
-    )
-
-    PHImageManager.default().requestImage(
-      for: asset,
-      targetSize: targetSize,
-      contentMode: .default,
-      options: options) { (image, _) in
-        completion(image)
+    public func resolve(completion: @escaping (UIImage?) -> Void) {
+        let options = PHImageRequestOptions()
+        options.isNetworkAccessAllowed = true
+        options.deliveryMode = .highQualityFormat
+        options.resizeMode = .exact;
+        
+        PHImageManager.default().requestImage(
+            for: asset,
+            targetSize: PHImageManagerMaximumSize,
+            contentMode: .default,
+            options: options) { (image, _) in
+                print(image!.size);
+                completion(image)
+        }
     }
-  }
 
   /// Resolve an array of Image
   ///


### PR DESCRIPTION
On iPhone 5s I got image resolution of 854x640
On iPhone 6s I got image resolution of 1000x750
I fixed this by changing the resolve function in the Image.swift class
adding .exact and removing targetSize instead using PHImageManagerMaximumSize
