### PR TITLE
Fix low image resolution

### DIFF
--- a/Sources/Camera/CameraMan.swift
+++ b/Sources/Camera/CameraMan.swift
@@ -227,6 +227,7 @@ class CameraMan {
 
   func preferredPresets() -> [AVCaptureSession.Preset] {
     return [
+      .photo,
       .high,
       .medium,
       .low


### PR DESCRIPTION
Fixes an issue where images taken with the camera are returning low resolution 1080p images, regardless of device.

By adding the `.photo` preset, the highest possible image quality will be used for photos.

Reference:
https://developer.apple.com/documentation/avfoundation/avcapturesessionpresetphoto?language=objc

iPhone camera photo size reference:
https://www.cameracompany.com/blog/how-large-can-you-print-iphone-photos/

Fixes #160 