### PR TITLE
Fix low quality thumbnails with Xcode 11

### DIFF
--- a/Sources/Utils/Extensions/UIImageView+Extensions.swift
+++ b/Sources/Utils/Extensions/UIImageView+Extensions.swift
@@ -17,6 +17,7 @@ extension UIImageView {
 
     let options = PHImageRequestOptions()
     options.isNetworkAccessAllowed = true
+    options.resizeMode = .none
 
     let id = PHImageManager.default().requestImage(
       for: asset,


### PR DESCRIPTION
## Description

When building the project with Xcode 11, the default value for `PHImageRequestOptions.resizeMode` is `.fast`. This causes the `PHImageManager` to send lower resolution images which appear blurred when displayed in the photo picker cells.

Xcode 10, iPhone 6s, default value ->`.none`: 256x342, sometimes 256x454
Xcode 11, iPhone 6s, default value -> `.fast`: 92x124 (looks blurred)

## Changes

- Explicitly set `resizeMode` to `.none`

`.none` is the default value when building the project with Xcode 10.


<table>
  <tr align="center">
    <td colspan="2" align="center"><b>Change 1</b></td>
  </tr>
  <tr>
    <td align="center">Before</td>
    <td align="center">After</td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/12001171/71971759-94c21d80-320b-11ea-98a0-d7193f4a0511.PNG" width="400"></td>
    <td><img src="https://user-images.githubusercontent.com/12001171/71971783-a0154900-320b-11ea-9cba-0e6f8331aa57.PNG" width="400"></td>
  </tr>
</table>

(Open in new tab for better comparison)